### PR TITLE
Fix the evaluation order of arguments.

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func run() int {
 				fmt.Fprintln(os.Stderr, err)
 				return 1
 			}
-			if len(keys) != 0 {
+			if len(keys) > 0 {
 				authMethods = append(authMethods, ssh.PublicKeysCallback(ag.Signers))
 			}
 		}


### PR DESCRIPTION
## 概要
* `-f` オプションを利用した場合であっても、`ssh-add` で鍵を追加していない時、`-f` が無視されてしまう
* `ssh-add`でアクセスに必要な鍵が追加されていない場合、サーバへのSSHが失敗する
* そこで、引数の評価順序を以下の通り変更

1. `-f`オプションがある場合、`ssh-agent` より優先して参照される
2. `-f`オプションがなければ、`ssh-agent` が参照される
3. `ssh-add`で登録された鍵が1個以上の場合、デフォルトの秘密鍵 `~/.ssh/id_rsa`より優先して参照される
4. `ssh-add`で登録された鍵が0個以下の場合、デフォルトの秘密鍵 `~/.ssh/id_rsa`が参照される

* その他、 鍵ファイルの存在チェックを追加